### PR TITLE
Fix registration lifecycle within the IoC container

### DIFF
--- a/src/AwsPubSubServiceProvider.php
+++ b/src/AwsPubSubServiceProvider.php
@@ -13,14 +13,13 @@ class AwsPubSubServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // ...
+        //
     }
 
     /**
      * Bootstrap any application services.
      *
      * @return void
-     * @throws BindingResolutionException
      */
     public function boot(): void
     {

--- a/src/Pub/Broadcasting/Broadcasters/SnsBroadcaster.php
+++ b/src/Pub/Broadcasting/Broadcasters/SnsBroadcaster.php
@@ -25,12 +25,13 @@ class SnsBroadcaster extends Broadcaster
     /**
      * SnsBroadcaster constructor.
      *
-     * @param string $arnPrefix
-     * @param string $arnSuffix
+     * @param  SnsClient  $snsClient
+     * @param  string  $arnPrefix
+     * @param  string  $arnSuffix
      */
-    public function __construct(string $arnPrefix = '', string $arnSuffix = '')
+    public function __construct(SnsClient $snsClient, string $arnPrefix = '', string $arnSuffix = '')
     {
-        $this->snsClient = app(SnsClient::class);
+        $this->snsClient = $snsClient;
         $this->arnPrefix = $arnPrefix;
         $this->arnSuffix = $arnSuffix;
     }
@@ -54,7 +55,7 @@ class SnsBroadcaster extends Broadcaster
      */
     public function auth($request)
     {
-        return true;
+        //
     }
 
     /**
@@ -62,6 +63,6 @@ class SnsBroadcaster extends Broadcaster
      */
     public function validAuthenticationResponse($request, $result)
     {
-        return true;
+        //
     }
 }

--- a/tests/Pub/BasicEventsTest.php
+++ b/tests/Pub/BasicEventsTest.php
@@ -2,9 +2,9 @@
 
 namespace PodPoint\AwsPubSub\Tests\Pub;
 
-use Aws\Sns\SnsClient;
-use Mockery;
+use Mockery as m;
 use Mockery\MockInterface;
+use PodPoint\AwsPubSub\Tests\Pub\Concerns\InteractsWithSns;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Events\UserRetrieved;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Events\UserRetrievedWithCustomName;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Events\UserRetrievedWithCustomPayload;
@@ -15,13 +15,15 @@ use PodPoint\AwsPubSub\Tests\TestCase;
 
 class BasicEventsTest extends TestCase
 {
+    use InteractsWithSns;
+
     /** @test */
     public function it_broadcasts_basic_event()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['user']['email'] === 'john@doe.com'
@@ -39,10 +41,10 @@ class BasicEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_with_action()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['user']['email'] === 'john@doe.com'
@@ -61,10 +63,10 @@ class BasicEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_with_action_and_custom_payload()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['data']['user']['email'] === 'john@doe.com'
@@ -83,10 +85,10 @@ class BasicEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_to_multiple_channels()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->twice()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['user']['email'] === 'john@doe.com'
@@ -104,10 +106,10 @@ class BasicEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_name_as_subject()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['user']['email'] === 'john@doe.com'
@@ -125,10 +127,10 @@ class BasicEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_name_as_subject_if_specified()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['user']['email'] === 'john@doe.com'

--- a/tests/Pub/Concerns/InteractsWithSns.php
+++ b/tests/Pub/Concerns/InteractsWithSns.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests\Pub\Concerns;
+
+use Aws\Sns\SnsClient;
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
+use Mockery as m;
+use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\SnsBroadcaster;
+
+trait InteractsWithSns
+{
+    /**
+     * Mocks the SnsClient through the SnsBroadcaster and the BroadcastManager.
+     *
+     * @param  \Closure|null  $mock
+     * @return void
+     */
+    private function mockSns(\Closure $mock = null)
+    {
+        $sns = m::mock(SnsClient::class, $mock);
+
+        $broadcaster = m::mock(SnsBroadcaster::class, [$sns])->makePartial();
+
+        $this->swap(BroadcasterContract::class, $broadcaster);
+
+        $manager = m::mock(BroadcastManager::class, [$this->app], function ($mock) use ($broadcaster) {
+            $mock->shouldReceive('connection')->andReturn($broadcaster);
+        })->makePartial();
+
+        $this->swap(BroadcastManager::class, $manager);
+    }
+}

--- a/tests/Pub/ModelEventsTest.php
+++ b/tests/Pub/ModelEventsTest.php
@@ -2,9 +2,9 @@
 
 namespace PodPoint\AwsPubSub\Tests\Pub;
 
-use Aws\Sns\SnsClient;
-use Mockery;
+use Mockery as m;
 use Mockery\MockInterface;
+use PodPoint\AwsPubSub\Tests\Pub\Concerns\InteractsWithSns;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Models\User;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Models\UserWithBroadcastingEvents;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Models\UserWithBroadcastingEventsWhenUpdatedOnly;
@@ -16,13 +16,15 @@ use PodPoint\AwsPubSub\Tests\TestCase;
 
 class ModelEventsTest extends TestCase
 {
+    use InteractsWithSns;
+
     /** @test */
     public function it_broadcasts_model_event()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['model']['email'] === 'john@doe.com';
@@ -39,8 +41,8 @@ class ModelEventsTest extends TestCase
     /** @test */
     public function it_does_not_broadcast_model_events_without_trait()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldNotHaveReceived('publish');
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldNotHaveReceived('publish');
         });
 
         User::create([
@@ -53,10 +55,10 @@ class ModelEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_model_event_with_custom_payload()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['data']['user']['email'] === 'john@doe.com'
@@ -81,10 +83,10 @@ class ModelEventsTest extends TestCase
             'password' => $this->faker->password(),
         ]);
 
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['model']['email'] === 'john@doe.com';
@@ -99,8 +101,8 @@ class ModelEventsTest extends TestCase
     /** @test */
     public function it_does_not_broadcast_model_event_without_specified_event()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldNotHaveReceived('publish');
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldNotHaveReceived('publish');
         });
 
         UserWithBroadcastingEventsWhenUpdatedOnly::create([
@@ -119,10 +121,10 @@ class ModelEventsTest extends TestCase
             'password' => $this->faker->password(),
         ]);
 
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['data']['user']['email'] === 'john@doe.com'
@@ -139,10 +141,10 @@ class ModelEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_model_events_to_multiple_channels()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->twice()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     $message = json_decode($argument['Message'], true);
 
                     return $message['model']['email'] === 'john@doe.com';
@@ -159,10 +161,10 @@ class ModelEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_model_event_name_as_subject()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     return $argument['Subject'] === 'UserWithBroadcastingEventsCreated';
                 }));
         });
@@ -177,10 +179,10 @@ class ModelEventsTest extends TestCase
     /** @test */
     public function it_broadcasts_model_event_name_as_subject_if_specified()
     {
-        $this->mock(SnsClient::class, function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+        $this->mockSns(function (MockInterface $sns) {
+            $sns->shouldReceive('publish')
                 ->once()
-                ->with(Mockery::on(function ($argument) {
+                ->with(m::on(function ($argument) {
                     return $argument['Subject'] === 'user.created';
                 }));
         });


### PR DESCRIPTION
- Fix problem when our ServiceProvider is not registering things soon enough using `$this->app->resolving()`
- Avoid using IoC container for `SnsClient` as you could end up with more than one
- Also improved mocking on the tests

Because a standard Laravel `config/app.php` would look like this
```php
// ...
Illuminate\Broadcasting\BroadcastServiceProvider::class,
// ...

/*
 * Application Service Providers...
 */
// ...
App\Providers\BroadcastServiceProvider::class,
// ...
App\Providers\PubSubEventServiceProvider::class,
```
Our ServiceProvider would get registering things too late in the lifecycle of the bootstrap of the application within the IoC container. This is why we had to use `$this->app->resolving()`.