### PR TITLE
0.4.x - Fix queue url passed to job

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.155",
-        "illuminate/support": "^8.52 || ^9.0",
-        "laravel/framework": "9.*"
+        "illuminate/support": "^8.52 || ^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.155",
-        "illuminate/support": "^8.52 || ^9.0"
+        "illuminate/support": "^8.52 || ^9.0",
+        "laravel/framework": "9.*"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0 || ^7.0"

--- a/src/Sub/Queue/SqsSnsQueue.php
+++ b/src/Sub/Queue/SqsSnsQueue.php
@@ -41,7 +41,7 @@ class SqsSnsQueue extends SqsQueue
     public function pop($queue = null)
     {
         $response = $this->sqs->receiveMessage([
-            'QueueUrl' => $this->getQueue($queue),
+            'QueueUrl' => $queue = $this->getQueue($queue),
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 

--- a/src/Sub/Queue/SqsSnsQueue.php
+++ b/src/Sub/Queue/SqsSnsQueue.php
@@ -40,8 +40,10 @@ class SqsSnsQueue extends SqsQueue
      */
     public function pop($queue = null)
     {
+        $queue = $this->getQueue($queue);
+
         $response = $this->sqs->receiveMessage([
-            'QueueUrl' => $queue = $this->getQueue($queue),
+            'QueueUrl' => $queue,
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 

--- a/tests/Sub/Queue/SqsSnsQueueTest.php
+++ b/tests/Sub/Queue/SqsSnsQueueTest.php
@@ -42,12 +42,31 @@ class SqsSnsQueueTest extends TestCase
     {
         $this->sqs->shouldReceive('receiveMessage')
             ->once()
+            ->with(['QueueUrl' => '/default', 'AttributeNames' => ['ApproximateReceiveCount']])
             ->andReturn($this->mockedRichNotificationMessage());
 
         $queue = new SqsSnsQueue($this->sqs, 'default');
         $queue->setContainer($this->app);
         $result = $queue->pop();
+
         $this->assertInstanceOf(SnsEventDispatcherJob::class, $result);
+        $this->assertEquals('/default', $result->getQueue());
+    }
+
+    /** @test */
+    public function it_should_use_the_queue_name_including_prefix_and_suffix()
+    {
+        $this->sqs->shouldReceive('receiveMessage')
+            ->once()
+            ->with(['QueueUrl' => 'prefix/default-suffix', 'AttributeNames' => ['ApproximateReceiveCount']])
+            ->andReturn($this->mockedRichNotificationMessage());
+
+        $queue = new SqsSnsQueue($this->sqs, 'default', 'prefix', '-suffix');
+        $queue->setContainer($this->app);
+        $result = $queue->pop();
+
+        $this->assertInstanceOf(SnsEventDispatcherJob::class, $result);
+        $this->assertEquals('prefix/default-suffix', $result->getQueue());
     }
 
     /** @test */


### PR DESCRIPTION
The queue url passed to the job should have prefix and suffix added.
