### PR TITLE
Introduce event dispatcher interface for SQS jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ Once the package is installed and similar to what you would do for a standard La
 ```php
 'connections' => [
     // ...
-    'pub_sub' => [
-        'driver' => 'pub_sub',
+    'sqs_pub_sub' => [
+        'driver' => 'sqs_pub_sub',
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
         'prefix' => env('SQS_SNS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),

--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ Once the package is installed and similar to what you would do for a standard La
 ```php
 'connections' => [
     // ...
-    'sqs-sns' => [
-        'driver' => 'sqs-sns',
+    'pub_sub' => [
+        'driver' => 'pub_sub',
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
         'prefix' => env('SQS_SNS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -22,7 +22,7 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->registerSnsBroadcaster();
 
-        $this->registerSqsSnsQueueConnector();
+        $this->registerPubSubQueueConnector();
 
         $this->registerEventBridgeBroadcaster();
     }
@@ -59,15 +59,15 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the SQS SNS connector for the Queue components.
+     * Register the pub sub connector for the Queue components.
      *
      * @return void
      */
-    protected function registerSqsSnsQueueConnector()
+    protected function registerPubSubQueueConnector()
     {
         $this->app->resolving('queue', function (QueueManager $manager) {
-            $manager->extend('sqs-sns', function () {
-                return new PubSubSqsConnector;
+            $manager->extend('pub_sub', function () {
+                return $this->app->make(PubSubSqsConnector::class);
             });
         });
     }

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -98,7 +98,7 @@ class EventServiceProvider extends ServiceProvider
     protected function registerPubSubQueueConnector()
     {
         $this->app->resolving('queue', function (QueueManager $manager) {
-            $manager->extend('pub_sub', function () {
+            $manager->extend('sqs_pub_sub', function () {
                 return $this->app->make(PubSubSqsConnector::class);
             });
         });

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -22,9 +22,9 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->registerSnsBroadcaster();
 
-        $this->registerPubSubQueueConnector();
-
         $this->registerEventBridgeBroadcaster();
+
+        $this->registerPubSubQueueConnector();
     }
 
     /**
@@ -59,20 +59,6 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the pub sub connector for the Queue components.
-     *
-     * @return void
-     */
-    protected function registerPubSubQueueConnector()
-    {
-        $this->app->resolving('queue', function (QueueManager $manager) {
-            $manager->extend('pub_sub', function () {
-                return $this->app->make(PubSubSqsConnector::class);
-            });
-        });
-    }
-
-    /**
      * Register the EventBridge broadcaster for the Broadcast components.
      *
      * @return void
@@ -102,6 +88,20 @@ class EventServiceProvider extends ServiceProvider
             new EventBridgeClient($config),
             $config['source'] ?? ''
         );
+    }
+
+    /**
+     * Register the pub sub connector for the Queue components.
+     *
+     * @return void
+     */
+    protected function registerPubSubQueueConnector()
+    {
+        $this->app->resolving('queue', function (QueueManager $manager) {
+            $manager->extend('pub_sub', function () {
+                return $this->app->make(PubSubSqsConnector::class);
+            });
+        });
     }
 
     /**

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Arr;
 use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\EventBridgeBroadcaster;
 use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\SnsBroadcaster;
-use PodPoint\AwsPubSub\Sub\Queue\Connectors\SqsSnsConnector;
+use PodPoint\AwsPubSub\Sub\Queue\Connectors\PubSubSqsConnector;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -67,7 +67,7 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->app->resolving('queue', function (QueueManager $manager) {
             $manager->extend('sqs-sns', function () {
-                return new SqsSnsConnector;
+                return new PubSubSqsConnector;
             });
         });
     }

--- a/src/Sub/EventDispatcherManager.php
+++ b/src/Sub/EventDispatcherManager.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Sub;
+
+use Illuminate\Support\Manager;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
+
+class EventDispatcherManager extends Manager
+{
+    public function getDefaultDriver()
+    {
+        return 'sns';
+    }
+
+    public function createSnsDriver()
+    {
+        return new SnsEventDispatcher();
+    }
+}

--- a/src/Sub/EventDispatcherManager.php
+++ b/src/Sub/EventDispatcherManager.php
@@ -14,6 +14,6 @@ class EventDispatcherManager extends Manager
 
     public function createSnsDriver()
     {
-        return new SnsEventDispatcher();
+        return $this->container->make(SnsEventDispatcher::class);
     }
 }

--- a/src/Sub/EventDispatchers/EventDispatcher.php
+++ b/src/Sub/EventDispatchers/EventDispatcher.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Sub\EventDispatchers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Jobs\SqsJob;
+
+interface EventDispatcher
+{
+    public function dispatch(SqsJob $job, Dispatcher $dispatcher): void;
+}

--- a/src/Sub/EventDispatchers/SnsEventDispatcher.php
+++ b/src/Sub/EventDispatchers/SnsEventDispatcher.php
@@ -4,18 +4,24 @@ namespace PodPoint\AwsPubSub\Sub\EventDispatchers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Jobs\SqsJob;
-use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
 
 class SnsEventDispatcher implements EventDispatcher
 {
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
     public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
     {
         if ($this->isRawPayload($job)) {
-            if ($job->getContainer()->bound('log')) {
-                Log::error('PubSubSqsQueue: Invalid SNS payload. '.
-                    'Make sure your JSON is a valid JSON object and raw '.
-                    'message delivery is disabled for your SQS subscription.', $job->getSqsJob());
-            }
+            $this->logger->error('PubSubSqsQueue: Invalid SNS payload. '.
+                'Make sure your JSON is a valid JSON object and raw '.
+                'message delivery is disabled for your SQS subscription.', $job->getSqsJob());
 
             return;
         }

--- a/src/Sub/EventDispatchers/SnsEventDispatcher.php
+++ b/src/Sub/EventDispatchers/SnsEventDispatcher.php
@@ -5,15 +5,16 @@ namespace PodPoint\AwsPubSub\Sub\EventDispatchers;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Jobs\SqsJob;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class SnsEventDispatcher implements EventDispatcher
 {
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(?LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function dispatch(SqsJob $job, Dispatcher $dispatcher): void

--- a/src/Sub/EventDispatchers/SnsEventDispatcher.php
+++ b/src/Sub/EventDispatchers/SnsEventDispatcher.php
@@ -12,7 +12,7 @@ class SnsEventDispatcher implements EventDispatcher
     {
         if ($this->isRawPayload($job)) {
             if ($job->getContainer()->bound('log')) {
-                Log::error('SqsSnsQueue: Invalid SNS payload. '.
+                Log::error('PubSubSqsQueue: Invalid SNS payload. '.
                     'Make sure your JSON is a valid JSON object and raw '.
                     'message delivery is disabled for your SQS subscription.', $job->getSqsJob());
             }

--- a/src/Sub/EventDispatchers/SnsEventDispatcher.php
+++ b/src/Sub/EventDispatchers/SnsEventDispatcher.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Sub\EventDispatchers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Jobs\SqsJob;
+use Illuminate\Support\Facades\Log;
+
+class SnsEventDispatcher implements EventDispatcher
+{
+    public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
+    {
+        if ($this->isRawPayload($job)) {
+            if ($job->getContainer()->bound('log')) {
+                Log::error('SqsSnsQueue: Invalid SNS payload. '.
+                    'Make sure your JSON is a valid JSON object and raw '.
+                    'message delivery is disabled for your SQS subscription.', $job->getSqsJob());
+            }
+
+            return;
+        }
+
+        if ($eventName = $this->resolveName($job)) {
+            $dispatcher->dispatch($eventName, [
+                'payload' => json_decode($this->snsMessage($job), true),
+                'subject' => $this->snsSubject($job),
+            ]);
+        }
+    }
+
+    /**
+     * Verifies that the SNS message sent to the queue can be processed.
+     *
+     * @return bool
+     */
+    private function isRawPayload(SqsJob $job)
+    {
+        return is_null($job->payload()['Type'] ?? null);
+    }
+
+    public function resolveName(SqsJob $job)
+    {
+        return $this->snsSubject($job) ?: $this->snsTopicArn($job);
+    }
+
+    /**
+     * Get the job SNS Topic identifier it was sent from.
+     *
+     * @return string
+     */
+    public function snsTopicArn(SqsJob $job)
+    {
+        return $job->payload()['TopicArn'] ?? '';
+    }
+
+    /**
+     * Get the job SNS subject.
+     *
+     * @return string
+     */
+    public function snsSubject(SqsJob $job)
+    {
+        return $job->payload()['Subject'] ?? '';
+    }
+
+    /**
+     * Get the job SNS message.
+     *
+     * @return string
+     */
+    public function snsMessage(SqsJob $job)
+    {
+        return $job->payload()['Message'] ?? '[]';
+    }
+}

--- a/src/Sub/Queue/Connectors/PubSubSqsConnector.php
+++ b/src/Sub/Queue/Connectors/PubSubSqsConnector.php
@@ -6,6 +6,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Support\Arr;
 use PodPoint\AwsPubSub\EventServiceProvider;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
 use PodPoint\AwsPubSub\Sub\Queue\PubSubSqsQueue;
 
 class PubSubSqsConnector extends SqsConnector
@@ -25,6 +26,8 @@ class PubSubSqsConnector extends SqsConnector
             $config['queue'],
             Arr::get($config, 'prefix', ''),
             Arr::get($config, 'suffix', ''),
+            false,
+            new SnsEventDispatcher()
         );
     }
 }

--- a/src/Sub/Queue/Connectors/PubSubSqsConnector.php
+++ b/src/Sub/Queue/Connectors/PubSubSqsConnector.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Arr;
 use PodPoint\AwsPubSub\EventServiceProvider;
 use PodPoint\AwsPubSub\Sub\Queue\SqsSnsQueue;
 
-class SqsSnsConnector extends SqsConnector
+class PubSubSqsConnector extends SqsConnector
 {
     /**
      * Establish a queue connection.

--- a/src/Sub/Queue/Connectors/PubSubSqsConnector.php
+++ b/src/Sub/Queue/Connectors/PubSubSqsConnector.php
@@ -6,11 +6,19 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Support\Arr;
 use PodPoint\AwsPubSub\EventServiceProvider;
-use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
+use PodPoint\AwsPubSub\Sub\EventDispatcherManager;
 use PodPoint\AwsPubSub\Sub\Queue\PubSubSqsQueue;
 
 class PubSubSqsConnector extends SqsConnector
 {
+    /** @var EventDispatcherManager */
+    private $eventDispatcherManager;
+
+    public function __construct(EventDispatcherManager $eventDispatcherManager)
+    {
+        $this->eventDispatcherManager = $eventDispatcherManager;
+    }
+
     /**
      * Establish a queue connection.
      *
@@ -27,7 +35,7 @@ class PubSubSqsConnector extends SqsConnector
             Arr::get($config, 'prefix', ''),
             Arr::get($config, 'suffix', ''),
             false,
-            new SnsEventDispatcher()
+            $this->eventDispatcherManager->driver(Arr::get($config, 'dispatcher')),
         );
     }
 }

--- a/src/Sub/Queue/Connectors/PubSubSqsConnector.php
+++ b/src/Sub/Queue/Connectors/PubSubSqsConnector.php
@@ -6,7 +6,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Support\Arr;
 use PodPoint\AwsPubSub\EventServiceProvider;
-use PodPoint\AwsPubSub\Sub\Queue\SqsSnsQueue;
+use PodPoint\AwsPubSub\Sub\Queue\PubSubSqsQueue;
 
 class PubSubSqsConnector extends SqsConnector
 {
@@ -20,7 +20,7 @@ class PubSubSqsConnector extends SqsConnector
     {
         $config = $this->getDefaultConfiguration($config);
 
-        return new SqsSnsQueue(
+        return new PubSubSqsQueue(
             new SqsClient(EventServiceProvider::prepareConfigurationCredentials($config)),
             $config['queue'],
             Arr::get($config, 'prefix', ''),

--- a/src/Sub/Queue/Jobs/EventDispatcherJob.php
+++ b/src/Sub/Queue/Jobs/EventDispatcherJob.php
@@ -32,7 +32,7 @@ class EventDispatcherJob extends SqsJob implements JobContract
      */
     public function fire()
     {
-        $this->eventDispatcher->dispatch($this, $this->container->make(Dispatcher::class));
+        $this->getEventDispatcher()->dispatch($this, $this->container->make(Dispatcher::class));
     }
 
     /**
@@ -49,5 +49,10 @@ class EventDispatcherJob extends SqsJob implements JobContract
     public function getName()
     {
         return self::class;
+    }
+
+    public function getEventDispatcher(): EventDispatcher
+    {
+        return $this->eventDispatcher;
     }
 }

--- a/src/Sub/Queue/Jobs/EventDispatcherJob.php
+++ b/src/Sub/Queue/Jobs/EventDispatcherJob.php
@@ -48,54 +48,6 @@ class EventDispatcherJob extends SqsJob implements JobContract
      */
     public function getName()
     {
-        return $this->snsSubject() ?: $this->snsTopicArn();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function resolveName()
-    {
-        return $this->getName();
-    }
-
-    /**
-     * Get the job SNS Topic identifier it was sent from.
-     *
-     * @return string
-     */
-    public function snsTopicArn()
-    {
-        return $this->payload()['TopicArn'] ?? '';
-    }
-
-    /**
-     * Get the job SNS subject.
-     *
-     * @return string
-     */
-    public function snsSubject()
-    {
-        return $this->payload()['Subject'] ?? '';
-    }
-
-    /**
-     * Get the job SNS message.
-     *
-     * @return string
-     */
-    public function snsMessage()
-    {
-        return $this->payload()['Message'] ?? '[]';
-    }
-
-    /**
-     * Get the job message type. If a raw SNS message was used, this will be missing.
-     *
-     * @return string|null
-     */
-    public function snsMessageType()
-    {
-        return $this->payload()['Type'] ?? null;
+        return self::class;
     }
 }

--- a/src/Sub/Queue/Jobs/EventDispatcherJob.php
+++ b/src/Sub/Queue/Jobs/EventDispatcherJob.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Support\Facades\Log;
 
-class SnsEventDispatcherJob extends SqsJob implements JobContract
+class EventDispatcherJob extends SqsJob implements JobContract
 {
     /**
      * @inheritDoc

--- a/src/Sub/Queue/PubSubSqsQueue.php
+++ b/src/Sub/Queue/PubSubSqsQueue.php
@@ -32,7 +32,7 @@ class PubSubSqsQueue extends SqsQueue
     public function pushRaw($payload, $queue = null, array $options = [])
     {
         if ($this->container->bound('log')) {
-            Log::error('Unsupported: sqs-sns queue driver is read-only');
+            Log::error('Unsupported: pub_sub queue driver is read-only');
         }
 
         return null;
@@ -44,7 +44,7 @@ class PubSubSqsQueue extends SqsQueue
     public function later($delay, $job, $data = '', $queue = null)
     {
         if ($this->container->bound('log')) {
-            Log::error('Unsupported: sqs-sns queue driver is read-only');
+            Log::error('Unsupported: pub_sub queue driver is read-only');
         }
 
         return null;

--- a/src/Sub/Queue/PubSubSqsQueue.php
+++ b/src/Sub/Queue/PubSubSqsQueue.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
 use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 
-class SqsSnsQueue extends SqsQueue
+class PubSubSqsQueue extends SqsQueue
 {
     /**
      * @inheritDoc

--- a/src/Sub/Queue/PubSubSqsQueue.php
+++ b/src/Sub/Queue/PubSubSqsQueue.php
@@ -2,13 +2,30 @@
 
 namespace PodPoint\AwsPubSub\Sub\Queue;
 
+use Aws\Sqs\SqsClient;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Facades\Log;
-use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher;
 use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 
 class PubSubSqsQueue extends SqsQueue
 {
+    /** @var EventDispatcher */
+    private $eventDispatcher;
+
+    public function __construct(
+        SqsClient $sqs,
+        $default,
+        $prefix,
+        $suffix,
+        $dispatchAfterCommit,
+        EventDispatcher $eventDispatcher
+    ) {
+        parent::__construct($sqs, $default, $prefix, $suffix, $dispatchAfterCommit);
+
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
     /**
      * @inheritDoc
      */
@@ -51,7 +68,7 @@ class PubSubSqsQueue extends SqsQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new EventDispatcherJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue, new SnsEventDispatcher()
+                $this->connectionName, $queue, $this->eventDispatcher
             );
         }
     }

--- a/src/Sub/Queue/PubSubSqsQueue.php
+++ b/src/Sub/Queue/PubSubSqsQueue.php
@@ -68,8 +68,13 @@ class PubSubSqsQueue extends SqsQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new EventDispatcherJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue, $this->eventDispatcher
+                $this->connectionName, $queue, $this->getEventDispatcher()
             );
         }
+    }
+
+    public function getEventDispatcher(): EventDispatcher
+    {
+        return $this->eventDispatcher;
     }
 }

--- a/src/Sub/Queue/PubSubSqsQueue.php
+++ b/src/Sub/Queue/PubSubSqsQueue.php
@@ -32,7 +32,7 @@ class PubSubSqsQueue extends SqsQueue
     public function pushRaw($payload, $queue = null, array $options = [])
     {
         if ($this->container->bound('log')) {
-            Log::error('Unsupported: pub_sub queue driver is read-only');
+            Log::error('Unsupported: sqs_pub_sub queue driver is read-only');
         }
 
         return null;
@@ -44,7 +44,7 @@ class PubSubSqsQueue extends SqsQueue
     public function later($delay, $job, $data = '', $queue = null)
     {
         if ($this->container->bound('log')) {
-            Log::error('Unsupported: pub_sub queue driver is read-only');
+            Log::error('Unsupported: sqs_pub_sub queue driver is read-only');
         }
 
         return null;

--- a/src/Sub/Queue/SqsSnsQueue.php
+++ b/src/Sub/Queue/SqsSnsQueue.php
@@ -4,7 +4,7 @@ namespace PodPoint\AwsPubSub\Sub\Queue;
 
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Facades\Log;
-use PodPoint\AwsPubSub\Sub\Queue\Jobs\SnsEventDispatcherJob;
+use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 
 class SqsSnsQueue extends SqsQueue
 {
@@ -48,7 +48,7 @@ class SqsSnsQueue extends SqsQueue
         ]);
 
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
-            return new SnsEventDispatcherJob(
+            return new EventDispatcherJob(
                 $this->container, $this->sqs, $response['Messages'][0],
                 $this->connectionName, $queue
             );

--- a/src/Sub/Queue/SqsSnsQueue.php
+++ b/src/Sub/Queue/SqsSnsQueue.php
@@ -4,6 +4,7 @@ namespace PodPoint\AwsPubSub\Sub\Queue;
 
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Facades\Log;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
 use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 
 class SqsSnsQueue extends SqsQueue
@@ -50,7 +51,7 @@ class SqsSnsQueue extends SqsQueue
         if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new EventDispatcherJob(
                 $this->container, $this->sqs, $response['Messages'][0],
-                $this->connectionName, $queue
+                $this->connectionName, $queue, new SnsEventDispatcher()
             );
         }
     }

--- a/tests/EventServiceProviderTest.php
+++ b/tests/EventServiceProviderTest.php
@@ -21,6 +21,6 @@ class EventServiceProviderTest extends TestCase
             'connect' => $queue,
         ]));
 
-        $this->assertEquals($queue, $this->app->make('queue')->connection('pub_sub'));
+        $this->assertEquals($queue, $this->app->make('queue')->connection('sqs_pub_sub'));
     }
 }

--- a/tests/EventServiceProviderTest.php
+++ b/tests/EventServiceProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests;
+
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\Connectors\ConnectorInterface;
+use Mockery as m;
+use PodPoint\AwsPubSub\Sub\Queue\Connectors\PubSubSqsConnector;
+
+class EventServiceProviderTest extends TestCase
+{
+    /** @test */
+    public function it_registers_a_queue_connector()
+    {
+        $queue = tap(m::mock(Queue::class), function ($queue) {
+            $queue->shouldReceive('setContainer')->andReturnSelf();
+            $queue->shouldReceive('setConnectionName')->andReturnSelf();
+        });
+
+        $this->app->instance(PubSubSqsConnector::class, m::mock(ConnectorInterface::class, [
+            'connect' => $queue,
+        ]));
+
+        $this->assertEquals($queue, $this->app->make('queue')->connection('pub_sub'));
+    }
+}

--- a/tests/Sub/EventDispatchers/SnsEventDispatcherTest.php
+++ b/tests/Sub/EventDispatchers/SnsEventDispatcherTest.php
@@ -118,7 +118,7 @@ class SnsEventDispatcherTest extends TestCase
     public function it_will_not_handle_raw_notification_messages()
     {
         Log::shouldReceive('error')->once()->with(
-            m::pattern('/^SqsSnsQueue: Invalid SNS payload/'),
+            m::pattern('/^PubSubSqsQueue: Invalid SNS payload/'),
             m::type('array')
         );
 

--- a/tests/Sub/EventDispatchers/SnsEventDispatcherTest.php
+++ b/tests/Sub/EventDispatchers/SnsEventDispatcherTest.php
@@ -144,7 +144,7 @@ class SnsEventDispatcherTest extends TestCase
 
     protected function getDispatcher()
     {
-        return new SnsEventDispatcher();
+        return $this->app->make(SnsEventDispatcher::class);
     }
 
     protected function getJob()

--- a/tests/Sub/EventDispatchers/SnsEventDispatcherTest.php
+++ b/tests/Sub/EventDispatchers/SnsEventDispatcherTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests\Sub\EventDispatchers;
+
+use Aws\Sqs\SqsClient;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Jobs\SqsJob;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Mockery as m;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
+use PodPoint\AwsPubSub\Tests\Sub\Concerns\MocksNotificationMessages;
+use PodPoint\AwsPubSub\Tests\TestCase;
+
+class SnsEventDispatcherTest extends TestCase
+{
+    use MocksNotificationMessages;
+
+    /**
+     * @var array
+     */
+    protected $mockedJobData = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+    }
+
+    /** @test */
+    public function it_can_dispatch_an_event_using_the_topic_and_forward_the_message_payload()
+    {
+        $this->mockedJobData = $this->mockedRichNotificationMessage([
+            'TopicArn' => 'TopicArn:123456',
+            'Message' => json_encode(['foo' => 'bar']),
+        ])['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertDispatched('TopicArn:123456', function ($event, $args) {
+            return $args === [
+                'payload' => ['foo' => 'bar'],
+                'subject' => '',
+            ];
+        });
+    }
+
+    /** @test */
+    public function it_can_dispatch_an_event_using_the_subject_if_found_in_the_notification_payload()
+    {
+        $this->mockedJobData = $this->mockedRichNotificationMessage([
+            'TopicArn' => 'TopicArn:123456',
+            'Subject' => 'Subject#action',
+            'Message' => json_encode(['foo' => 'bar']),
+        ])['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertDispatched('Subject#action', function ($event, $payload) {
+            return $payload === [
+                'payload' => ['foo' => 'bar'],
+                'subject' => 'Subject#action',
+            ];
+        });
+        Event::assertNotDispatched('TopicArn:123456');
+    }
+
+    /** @test */
+    public function it_dispatches_an_event_using_the_topic_if_no_subject_can_be_found()
+    {
+        $this->mockedJobData = $this->mockedRichNotificationMessage([
+            'TopicArn' => 'TopicArn:123456',
+        ])['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertDispatched('TopicArn:123456');
+    }
+
+    /** @test */
+    public function it_will_handle_empty_messages()
+    {
+        $this->mockedJobData = $this->mockedRichNotificationMessage([
+            'TopicArn' => 'TopicArn:123456',
+            'Message' => null,
+        ])['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertDispatched('TopicArn:123456', function ($event, $payload) {
+            return $payload === [
+                'payload' => [],
+                'subject' => '',
+            ];
+        });
+    }
+
+    /** @test */
+    public function it_will_handle_empty_messages_with_a_subject()
+    {
+        $this->mockedJobData = $this->mockedRichNotificationMessage([
+            'Subject' => 'Subject#action',
+            'Message' => null,
+        ])['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertDispatched('Subject#action', function ($event, $payload) {
+            return $payload === [
+                'payload' => [],
+                'subject' => 'Subject#action',
+            ];
+        });
+    }
+
+    /** @test */
+    public function it_will_not_handle_raw_notification_messages()
+    {
+        Log::shouldReceive('error')->once()->with(
+            m::pattern('/^SqsSnsQueue: Invalid SNS payload/'),
+            m::type('array')
+        );
+
+        $this->mockedJobData = $this->mockedRawNotificationMessage()['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertNothingDispatched();
+    }
+
+    /** @test */
+    public function it_will_not_handle_messages_where_the_event_name_to_trigger_cannot_be_resolved()
+    {
+        $this->mockedJobData = $this->mockedRichNotificationMessage([
+            'TopicArn' => '',
+            'Subject' => '',
+        ])['Messages'][0];
+
+        $this->getDispatcher()->dispatch($this->getJob(), $this->app->make(Dispatcher::class));
+
+        Event::assertNothingDispatched();
+    }
+
+    protected function getDispatcher()
+    {
+        return new SnsEventDispatcher();
+    }
+
+    protected function getJob()
+    {
+        return new SqsJob(
+            $this->app,
+            m::mock(SqsClient::class),
+            $this->mockedJobData,
+            'connection-name',
+            'https://sqs.someregion.amazonaws.com/1234567891011/pubsub-events'
+        );
+    }
+}

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -65,6 +65,16 @@ class PubSubSqsConnectorTest extends TestCase
         $this->assertInstanceOf(SnsEventDispatcher::class, $queue->getEventDispatcher());
     }
 
+    /** @test */
+    public function it_uses_the_sns_event_dispatcher_if_specified()
+    {
+        config(['queue.connections.pub_sub.dispatcher' => 'sns']);
+
+        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
+
+        $this->assertInstanceOf(SnsEventDispatcher::class, $queue->getEventDispatcher());
+    }
+
     private function getConnector(?EventDispatcherManager $manager = null): PubSubSqsConnector
     {
         return new PubSubSqsConnector($manager ?? $this->app->make(EventDispatcherManager::class));

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -3,7 +3,7 @@
 namespace PodPoint\AwsPubSub\Tests\Sub\Queue\Connectors;
 
 use PodPoint\AwsPubSub\Sub\Queue\Connectors\PubSubSqsConnector;
-use PodPoint\AwsPubSub\Sub\Queue\SqsSnsQueue;
+use PodPoint\AwsPubSub\Sub\Queue\PubSubSqsQueue;
 use PodPoint\AwsPubSub\Tests\TestCase;
 
 class PubSubSqsConnectorTest extends TestCase
@@ -13,7 +13,7 @@ class PubSubSqsConnectorTest extends TestCase
     {
         $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
 
-        $this->assertInstanceOf(SqsSnsQueue::class, $queue);
+        $this->assertInstanceOf(PubSubSqsQueue::class, $queue);
     }
 
     /** @test */

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -16,7 +16,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_instantiate_the_connector_and_connect_to_the_queue()
     {
-        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
 
         $this->assertInstanceOf(PubSubSqsQueue::class, $queue);
     }
@@ -24,7 +24,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_prefix()
     {
-        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
     }
@@ -32,9 +32,9 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_suffix()
     {
-        config(['queue.connections.pub-sub.suffix' => '-testing']);
+        config(['queue.connections.pub_sub.suffix' => '-testing']);
 
-        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default-testing', $queue->getQueue(null));
     }
@@ -50,9 +50,9 @@ class PubSubSqsConnectorTest extends TestCase
             });
         });
 
-        config(['queue.connections.pub-sub.dispatcher' => 'test_dispatcher']);
+        config(['queue.connections.pub_sub.dispatcher' => 'test_dispatcher']);
 
-        $queue = $this->getConnector($manager)->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector($manager)->connect(config('queue.connections.pub_sub'));
 
         $this->assertEquals($testDispatcher, $queue->getEventDispatcher());
     }
@@ -60,7 +60,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_uses_the_sns_event_dispatcher_by_default()
     {
-        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
 
         $this->assertInstanceOf(SnsEventDispatcher::class, $queue->getEventDispatcher());
     }

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -2,16 +2,16 @@
 
 namespace PodPoint\AwsPubSub\Tests\Sub\Queue\Connectors;
 
-use PodPoint\AwsPubSub\Sub\Queue\Connectors\SqsSnsConnector;
+use PodPoint\AwsPubSub\Sub\Queue\Connectors\PubSubSqsConnector;
 use PodPoint\AwsPubSub\Sub\Queue\SqsSnsQueue;
 use PodPoint\AwsPubSub\Tests\TestCase;
 
-class SqsSnsConnectorTest extends TestCase
+class PubSubSqsConnectorTest extends TestCase
 {
     /** @test */
     public function it_can_instantiate_the_connector_and_connect_to_the_queue()
     {
-        $queue = (new SqsSnsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
 
         $this->assertInstanceOf(SqsSnsQueue::class, $queue);
     }
@@ -19,7 +19,7 @@ class SqsSnsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_prefix()
     {
-        $queue = (new SqsSnsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
     }
@@ -29,7 +29,7 @@ class SqsSnsConnectorTest extends TestCase
     {
         config(['queue.connections.pub-sub.suffix' => '-testing']);
 
-        $queue = (new SqsSnsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default-testing', $queue->getQueue(null));
     }

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -16,7 +16,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_instantiate_the_connector_and_connect_to_the_queue()
     {
-        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.sqs_pub_sub'));
 
         $this->assertInstanceOf(PubSubSqsQueue::class, $queue);
     }
@@ -24,7 +24,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_prefix()
     {
-        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.sqs_pub_sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
     }
@@ -32,9 +32,9 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_suffix()
     {
-        config(['queue.connections.pub_sub.suffix' => '-testing']);
+        config(['queue.connections.sqs_pub_sub.suffix' => '-testing']);
 
-        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.sqs_pub_sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default-testing', $queue->getQueue(null));
     }
@@ -50,9 +50,9 @@ class PubSubSqsConnectorTest extends TestCase
             });
         });
 
-        config(['queue.connections.pub_sub.dispatcher' => 'test_dispatcher']);
+        config(['queue.connections.sqs_pub_sub.dispatcher' => 'test_dispatcher']);
 
-        $queue = $this->getConnector($manager)->connect(config('queue.connections.pub_sub'));
+        $queue = $this->getConnector($manager)->connect(config('queue.connections.sqs_pub_sub'));
 
         $this->assertEquals($testDispatcher, $queue->getEventDispatcher());
     }
@@ -60,7 +60,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_uses_the_sns_event_dispatcher_by_default()
     {
-        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.sqs_pub_sub'));
 
         $this->assertInstanceOf(SnsEventDispatcher::class, $queue->getEventDispatcher());
     }
@@ -68,9 +68,9 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_uses_the_sns_event_dispatcher_if_specified()
     {
-        config(['queue.connections.pub_sub.dispatcher' => 'sns']);
+        config(['queue.connections.sqs_pub_sub.dispatcher' => 'sns']);
 
-        $queue = $this->getConnector()->connect(config('queue.connections.pub_sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.sqs_pub_sub'));
 
         $this->assertInstanceOf(SnsEventDispatcher::class, $queue->getEventDispatcher());
     }

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -2,6 +2,11 @@
 
 namespace PodPoint\AwsPubSub\Tests\Sub\Queue\Connectors;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Jobs\SqsJob;
+use PodPoint\AwsPubSub\Sub\EventDispatcherManager;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
 use PodPoint\AwsPubSub\Sub\Queue\Connectors\PubSubSqsConnector;
 use PodPoint\AwsPubSub\Sub\Queue\PubSubSqsQueue;
 use PodPoint\AwsPubSub\Tests\TestCase;
@@ -11,7 +16,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_instantiate_the_connector_and_connect_to_the_queue()
     {
-        $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
 
         $this->assertInstanceOf(PubSubSqsQueue::class, $queue);
     }
@@ -19,7 +24,7 @@ class PubSubSqsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_prefix()
     {
-        $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
     }
@@ -29,8 +34,49 @@ class PubSubSqsConnectorTest extends TestCase
     {
         config(['queue.connections.pub-sub.suffix' => '-testing']);
 
-        $queue = (new PubSubSqsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default-testing', $queue->getQueue(null));
+    }
+
+    /** @test */
+    public function it_creates_a_queue_using_the_event_dispatcher_from_config()
+    {
+        $testDispatcher = $this->getEventDispatcher();
+
+        $manager = tap($this->app->make(EventDispatcherManager::class), function($manager) use ($testDispatcher) {
+            $manager->extend('test_dispatcher', function () use ($testDispatcher) {
+                return $testDispatcher;
+            });
+        });
+
+        config(['queue.connections.pub-sub.dispatcher' => 'test_dispatcher']);
+
+        $queue = $this->getConnector($manager)->connect(config('queue.connections.pub-sub'));
+
+        $this->assertEquals($testDispatcher, $queue->getEventDispatcher());
+    }
+
+    /** @test */
+    public function it_uses_the_sns_event_dispatcher_by_default()
+    {
+        $queue = $this->getConnector()->connect(config('queue.connections.pub-sub'));
+
+        $this->assertInstanceOf(SnsEventDispatcher::class, $queue->getEventDispatcher());
+    }
+
+    private function getConnector(?EventDispatcherManager $manager = null): PubSubSqsConnector
+    {
+        return new PubSubSqsConnector($manager ?? $this->app->make(EventDispatcherManager::class));
+    }
+
+    private function getEventDispatcher()
+    {
+        return new class implements EventDispatcher {
+            public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
+            {
+
+            }
+        };
     }
 }

--- a/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/PubSubSqsConnectorTest.php
@@ -44,7 +44,7 @@ class PubSubSqsConnectorTest extends TestCase
     {
         $testDispatcher = $this->getEventDispatcher();
 
-        $manager = tap($this->app->make(EventDispatcherManager::class), function($manager) use ($testDispatcher) {
+        $manager = tap($this->app->make(EventDispatcherManager::class), function ($manager) use ($testDispatcher) {
             $manager->extend('test_dispatcher', function () use ($testDispatcher) {
                 return $testDispatcher;
             });
@@ -72,10 +72,10 @@ class PubSubSqsConnectorTest extends TestCase
 
     private function getEventDispatcher()
     {
-        return new class implements EventDispatcher {
+        return new class implements EventDispatcher
+        {
             public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
             {
-
             }
         };
     }

--- a/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
+++ b/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
@@ -13,6 +13,16 @@ use PodPoint\AwsPubSub\Tests\TestCase;
 class EventDispatcherJobTest extends TestCase
 {
     /** @test */
+    public function it_has_an_event_dispatcher()
+    {
+        $eventDispatcher = m::mock(EventDispatcher::class);
+
+        $job = $this->getJob($eventDispatcher);
+
+        $this->assertEquals($eventDispatcher, $job->getEventDispatcher());
+    }
+
+    /** @test */
     public function it_calls_the_provided_event_dispatcher()
     {
         $eventDispatcher = m::spy(EventDispatcher::class);

--- a/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
+++ b/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
@@ -40,7 +40,7 @@ class EventDispatcherJobTest extends TestCase
             [],
             'connection-name',
             'https://sqs.someregion.amazonaws.com/1234567891011/pubsub-events',
-            $eventDispatcher ?? new SnsEventDispatcher(),
+            $eventDispatcher ?? $this->app->make(SnsEventDispatcher::class),
         );
     }
 }

--- a/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
+++ b/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
@@ -6,11 +6,11 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Mockery as m;
-use PodPoint\AwsPubSub\Sub\Queue\Jobs\SnsEventDispatcherJob;
+use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 use PodPoint\AwsPubSub\Tests\Sub\Concerns\MocksNotificationMessages;
 use PodPoint\AwsPubSub\Tests\TestCase;
 
-class SnsEventDispatcherJobTest extends TestCase
+class EventDispatcherJobTest extends TestCase
 {
     use MocksNotificationMessages;
 
@@ -142,7 +142,7 @@ class SnsEventDispatcherJobTest extends TestCase
 
     protected function getJob()
     {
-        return new SnsEventDispatcherJob(
+        return new EventDispatcherJob(
             $this->app,
             m::mock(SqsClient::class),
             $this->mockedJobData,

--- a/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
+++ b/tests/Sub/Queue/Jobs/EventDispatcherJobTest.php
@@ -6,6 +6,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Events\Dispatcher;
 use Mockery as m;
 use PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher;
+use PodPoint\AwsPubSub\Sub\EventDispatchers\SnsEventDispatcher;
 use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 use PodPoint\AwsPubSub\Tests\TestCase;
 
@@ -25,7 +26,13 @@ class EventDispatcherJobTest extends TestCase
             ->with($job, $this->app->make(Dispatcher::class));
     }
 
-    protected function getJob(EventDispatcher $eventDispatcher)
+    /** @test */
+    public function it_has_a_name()
+    {
+        $this->assertEquals(EventDispatcherJob::class, $this->getJob()->getName());
+    }
+
+    protected function getJob(?EventDispatcher $eventDispatcher = null)
     {
         return new EventDispatcherJob(
             $this->app,
@@ -33,7 +40,7 @@ class EventDispatcherJobTest extends TestCase
             [],
             'connection-name',
             'https://sqs.someregion.amazonaws.com/1234567891011/pubsub-events',
-            $eventDispatcher,
+            $eventDispatcher ?? new SnsEventDispatcher(),
         );
     }
 }

--- a/tests/Sub/Queue/PubSubSqsQueueTest.php
+++ b/tests/Sub/Queue/PubSubSqsQueueTest.php
@@ -106,7 +106,7 @@ class PubSubSqsQueueTest extends TestCase
     /** @test @dataProvider readOnlyDataProvider */
     public function it_is_a_read_only_queue_driver_and_will_not_push_messages_onto_a_queue(string $method, ...$args)
     {
-        Log::shouldReceive('error')->once()->with('Unsupported: sqs-sns queue driver is read-only');
+        Log::shouldReceive('error')->once()->with('Unsupported: pub_sub queue driver is read-only');
         $this->sqs->shouldNotReceive('sendMessage');
 
         $queue = $this->getQueue(['sqs' => $this->sqs, 'default' => 'default']);

--- a/tests/Sub/Queue/PubSubSqsQueueTest.php
+++ b/tests/Sub/Queue/PubSubSqsQueueTest.php
@@ -85,13 +85,23 @@ class PubSubSqsQueueTest extends TestCase
     }
 
     /** @test */
+    public function it_has_an_event_dispatcher()
+    {
+        $eventDispatcher = m::mock(EventDispatcher::class);
+
+        $queue = $this->getQueue(['eventDispatcher' => $eventDispatcher]);
+
+        $this->assertEquals($eventDispatcher, $queue->getEventDispatcher());
+    }
+
+    /** @test */
     public function it_provides_the_job_with_its_event_dispatcher()
     {
         $eventDispatcher = m::mock(EventDispatcher::class);
 
         $queue = $this->getQueue(['eventDispatcher' => $eventDispatcher]);
 
-        $this->assertEquals($eventDispatcher, $queue->pop()->getEventDispatcher());
+        $this->assertEquals($queue->getEventDispatcher(), $queue->pop()->getEventDispatcher());
     }
 
     public function readOnlyDataProvider(): array

--- a/tests/Sub/Queue/PubSubSqsQueueTest.php
+++ b/tests/Sub/Queue/PubSubSqsQueueTest.php
@@ -7,11 +7,11 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Mockery as m;
 use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
-use PodPoint\AwsPubSub\Sub\Queue\SqsSnsQueue;
+use PodPoint\AwsPubSub\Sub\Queue\PubSubSqsQueue;
 use PodPoint\AwsPubSub\Tests\Sub\Concerns\MocksNotificationMessages;
 use PodPoint\AwsPubSub\Tests\TestCase;
 
-class SqsSnsQueueTest extends TestCase
+class PubSubSqsQueueTest extends TestCase
 {
     use MocksNotificationMessages;
 
@@ -32,9 +32,9 @@ class SqsSnsQueueTest extends TestCase
     /** @test */
     public function it_can_instantiate_the_queue()
     {
-        $queue = new SqsSnsQueue($this->sqs, 'default');
+        $queue = new PubSubSqsQueue($this->sqs, 'default');
 
-        $this->assertInstanceOf(SqsSnsQueue::class, $queue);
+        $this->assertInstanceOf(PubSubSqsQueue::class, $queue);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class SqsSnsQueueTest extends TestCase
             ->with(['QueueUrl' => '/default', 'AttributeNames' => ['ApproximateReceiveCount']])
             ->andReturn($this->mockedRichNotificationMessage());
 
-        $queue = new SqsSnsQueue($this->sqs, 'default');
+        $queue = new PubSubSqsQueue($this->sqs, 'default');
         $queue->setContainer($this->app);
         $result = $queue->pop();
 
@@ -61,7 +61,7 @@ class SqsSnsQueueTest extends TestCase
             ->with(['QueueUrl' => 'prefix/default-suffix', 'AttributeNames' => ['ApproximateReceiveCount']])
             ->andReturn($this->mockedRichNotificationMessage());
 
-        $queue = new SqsSnsQueue($this->sqs, 'default', 'prefix', '-suffix');
+        $queue = new PubSubSqsQueue($this->sqs, 'default', 'prefix', '-suffix');
         $queue->setContainer($this->app);
         $result = $queue->pop();
 
@@ -76,7 +76,7 @@ class SqsSnsQueueTest extends TestCase
             ->once()
             ->andReturn($this->mockedEmptyNotificationMessage());
 
-        $queue = new SqsSnsQueue($this->sqs, 'default');
+        $queue = new PubSubSqsQueue($this->sqs, 'default');
         $queue->setContainer($this->app);
 
         $this->assertNull($queue->pop());
@@ -97,7 +97,7 @@ class SqsSnsQueueTest extends TestCase
         Log::shouldReceive('error')->once()->with('Unsupported: sqs-sns queue driver is read-only');
         $this->sqs->shouldNotReceive('sendMessage');
 
-        $queue = new SqsSnsQueue($this->sqs, 'default');
+        $queue = new PubSubSqsQueue($this->sqs, 'default');
         $queue->setContainer($this->app);
         $queue->$method(...$args);
     }

--- a/tests/Sub/Queue/PubSubSqsQueueTest.php
+++ b/tests/Sub/Queue/PubSubSqsQueueTest.php
@@ -116,7 +116,7 @@ class PubSubSqsQueueTest extends TestCase
     /** @test @dataProvider readOnlyDataProvider */
     public function it_is_a_read_only_queue_driver_and_will_not_push_messages_onto_a_queue(string $method, ...$args)
     {
-        Log::shouldReceive('error')->once()->with('Unsupported: pub_sub queue driver is read-only');
+        Log::shouldReceive('error')->once()->with('Unsupported: sqs_pub_sub queue driver is read-only');
         $this->sqs->shouldNotReceive('sendMessage');
 
         $queue = $this->getQueue(['sqs' => $this->sqs, 'default' => 'default']);

--- a/tests/Sub/Queue/PubSubSqsQueueTest.php
+++ b/tests/Sub/Queue/PubSubSqsQueueTest.php
@@ -116,12 +116,10 @@ class PubSubSqsQueueTest extends TestCase
 
     public function getQueue($parameterOverrides = []): PubSubSqsQueue
     {
-        $sqs = tap(m::mock(SqsClient::class), function ($sqs) {
-            return $sqs->shouldReceive('receiveMessage')->andReturn($this->mockedRichNotificationMessage());
-        });
-
         $parameters = array_merge([
-            'sqs' => $sqs,
+            'sqs' => m::mock(SqsClient::class, [
+                'receiveMessage' => $this->mockedRichNotificationMessage(),
+            ]),
             'default' => '',
             'prefix' => '',
             'suffix' => '',

--- a/tests/Sub/Queue/SqsSnsQueueTest.php
+++ b/tests/Sub/Queue/SqsSnsQueueTest.php
@@ -6,7 +6,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Mockery as m;
-use PodPoint\AwsPubSub\Sub\Queue\Jobs\SnsEventDispatcherJob;
+use PodPoint\AwsPubSub\Sub\Queue\Jobs\EventDispatcherJob;
 use PodPoint\AwsPubSub\Sub\Queue\SqsSnsQueue;
 use PodPoint\AwsPubSub\Tests\Sub\Concerns\MocksNotificationMessages;
 use PodPoint\AwsPubSub\Tests\TestCase;
@@ -49,7 +49,7 @@ class SqsSnsQueueTest extends TestCase
         $queue->setContainer($this->app);
         $result = $queue->pop();
 
-        $this->assertInstanceOf(SnsEventDispatcherJob::class, $result);
+        $this->assertInstanceOf(EventDispatcherJob::class, $result);
         $this->assertEquals('/default', $result->getQueue());
     }
 
@@ -65,7 +65,7 @@ class SqsSnsQueueTest extends TestCase
         $queue->setContainer($this->app);
         $result = $queue->pop();
 
-        $this->assertInstanceOf(SnsEventDispatcherJob::class, $result);
+        $this->assertInstanceOf(EventDispatcherJob::class, $result);
         $this->assertEquals('prefix/default-suffix', $result->getQueue());
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,8 +107,8 @@ abstract class TestCase extends Orchestra
     protected function setSubQueue($app): void
     {
         /** SUB */
-        $app['config']->set('queue.connections.pub-sub', [
-            'driver' => 'sqs-sns',
+        $app['config']->set('queue.connections.pub_sub', [
+            'driver' => 'pub_sub',
             'key' => 'dummy-key',
             'secret' => 'dummy-secret',
             'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,8 +107,8 @@ abstract class TestCase extends Orchestra
     protected function setSubQueue($app): void
     {
         /** SUB */
-        $app['config']->set('queue.connections.pub_sub', [
-            'driver' => 'pub_sub',
+        $app['config']->set('queue.connections.sqs_pub_sub', [
+            'driver' => 'sqs_pub_sub',
             'key' => 'dummy-key',
             'secret' => 'dummy-secret',
             'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',


### PR DESCRIPTION
This PR introduces an Event Dispatcher interface to allow users to define how jobs from SQS are dispatched as Laravel events.

By allowing you to dispatch events however you like, we no longer require that events originate from SNS or follow any particular structure.

We provide an `SnsEventDispatcher` implementation that is used by default and preserves the previous behaviour of this library.

## Usage

First, implement the `PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher` interface:

```php
<?php
use Illuminate\Contracts\Events\Dispatcher;
use Illuminate\Queue\Jobs\SqsJob;

class OrderEventDispatcher implements \PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher
{
    public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
    {
        // dispatch an event
    }
}
```

Next, in the `boot` method of a service provider (e.g. your `App\Providers\PubSubEventServiceProvider`), register your dispatcher with the dispatcher manager:

```php
public function boot(EventDispatcherManager $manager)
{
    $manager->extend('order_events', function($app) {
        return new OrderEventsEventDispatcher();
    });
}
```

Finally, specify the dispatcher (using the key with which it was registered) in your `config/queue.php` config file:

```php
'connections' => [
    // ...
    'sqs_order_events' => [
        'driver' => 'sqs_pub_sub',
        'key' => env('AWS_ACCESS_KEY_ID'),
        'secret' => env('AWS_SECRET_ACCESS_KEY'),
        'prefix' => env('SQS_SNS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
        'queue' => env('SQS_SNS_QUEUE', 'order-events'),
        'suffix' => env('SQS_SNS_SUFFIX'),
        'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
        'dispatcher' => 'order_events',
    ],
    // ...
],
```

## Examples

The `EventDispatcher` interface defines a single `dispatch` method that receives an `SqsJob` and Laravel `Dispatcher`, and leaves it up to you how the `SqsJob` is converted into a Laravel event for consumption by event listeners.

As with Laravel events, you can opt to add custom event classes, or use an event name and payload:

```php
class OrderEventDispatcher implements \PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher
{
    public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
    {
        // ...
        $dispatcher->dispatch('order.shipped', $orderEventPayload);
        // or
        $dispatcher->dispatch(new \App\Events\OrderShipped());
    }
}
```

Some examples are included below:

### SNS dispatcher
We ship a `SnsEventDispatcher` that provides the original SNS functionality of the library; dispatching the event using either the SNS message subject or topic ARN as the event name, and the message itself as the payload.

This is used by default if no `dispatcher` is specified in the config, or can be explicitly referenced via the `sns` dispatcher:

```php
'sqs_order_events' => [
    'driver' => 'sqs_pub_sub',
    'key' => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'prefix' => env('SQS_SNS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
    'queue' => env('SQS_SNS_QUEUE', 'order-events'),
    'suffix' => env('SQS_SNS_SUFFIX'),
    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
    'dispatcher' => 'sns',
],
```

### Payload path
For `SqsJob` payloads that do not originate from SNS, you may wish to specify a different path for the location of the event name and payload within the `SqsJob` payload. For example, if events originate from [EventBridge](https://aws.amazon.com/eventbridge/), and you wished to use the `detail-type` as the name of the Laravel event and a `data` key from within `detail` as the payload, you could use the following:

```php
public function boot(EventDispatcherManager $manager)
{
    $manager->extend('order_events', function() {
        return new PayloadPathEventDispatcher('detail-type', 'detail.data');
    });
}
```

Where the event dispatcher is defined as:

```php
class PayloadPathEventDispatcher implements \PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher
{
    private $namePath;
    private $payloadPath;

    public function __construct(string $namePath, string $payloadPath)
    {
        $this->namePath = $namePath;
        $this->payloadPath = $payloadPath;
    }

    public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
    {
        $dispatcher->dispatch(
            Arr::get($job->payload(), $this->namePath, ''),
            Arr::get($job->payload(), $this->payloadPath, ''),
        );
    }
}
```

### Custom classes
You can add any logic you wish to map the `SqsJob` to your own custom events. For example:

```php
use Illuminate\Contracts\Events\Dispatcher;
use Illuminate\Queue\Jobs\SqsJob;

class OrderEventDispatcher implements \PodPoint\AwsPubSub\Sub\EventDispatchers\EventDispatcher
{
    private $events = [
        'order.created' => OrderCreated::class,
        'order.shipped' => OrderShipped::class,
    ];

    public function dispatch(SqsJob $job, Dispatcher $dispatcher): void
    {
        $eventClass = $this->events[$job->payload()['Subject']];

        $dispatcher->dispatch(new $eventClass($job->payload()['Message']));
    }
}
```

Allowing you to listen for events as follows in your service provider:

```php
protected $listen = [
    OrderCreated::class => [
        SendConfirmationNotification::class,
    ],
    OrderShipped::class => [
        SendShipmentNotification::class,
    ],
];
```

And receive an event object in your listener handle methods:

```php
public function handle(OrderShipped $event)
{
    // ...
}
```

## Validation

You are welcome to add any validation of the `SqsJob` into the dispatch method should you wish. For example, in the `SnsEventDispatcher` we check that the job is not using raw message delivery before dispatching:

```php
if ($this->isRawPayload($job)) {
    $this->logger->error('PubSubSqsQueue: Invalid SNS payload. '.
        'Make sure your JSON is a valid JSON object and raw '.
        'message delivery is disabled for your SQS subscription.', $job->getSqsJob());

    return;
}
```

Other examples could include checking that an event is one that can be handled, or validating event payload structure.

## Breaking changes
- The queue driver has been renamed from `sqs-sns` to `sqs_pub_sub` to reflect the move away from being SNS specific. This will need to be updated accordingly in `config/queue.php`

## Todo
- Update `README.md` adapting the above, once we are happy with the approach
