### PR TITLE
[SWP-5671] Support null AWS credentials for assumed IAM roles

### DIFF
--- a/tests/Pub/BasicEvents/EventBridgeTest.php
+++ b/tests/Pub/BasicEvents/EventBridgeTest.php
@@ -2,8 +2,7 @@
 
 namespace PodPoint\AwsPubSub\Tests\Pub\BasicEvents;
 
-use Illuminate\Foundation\Application;
-use Mockery;
+use Mockery as m;
 use Mockery\MockInterface;
 use PodPoint\AwsPubSub\Tests\Pub\Concerns\InteractsWithEventBridge;
 use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Events\UserRetrieved;
@@ -17,28 +16,16 @@ class EventBridgeTest extends TestCase
 {
     use InteractsWithEventBridge;
 
-    /**
-     * @param  Application  $app
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        $this->setEventBridgeBroadcaster($app);
-
-        $this->setTestDatabase($app);
-    }
-
     /** @test */
     public function it_broadcasts_basic_event_with_the_event_name_as_the_detail_type_and_serialised_event_as_the_detail()
     {
-        $jane = $this->createJane();
-
-        $janeRetrieved = new UserRetrieved($jane);
+        $janeRetrieved = new UserRetrieved($this->createJane());
 
         $this->mockEventBridge(function (MockInterface $eventBridge) use ($janeRetrieved) {
             $eventBridge
                 ->shouldReceive('putEvents')
                 ->once()
-                ->with(Mockery::on(function ($arg) use ($janeRetrieved) {
+                ->with(m::on(function ($arg) use ($janeRetrieved) {
                     return $arg['Entries'][0]['Detail'] === json_encode($janeRetrieved)
                         && $arg['Entries'][0]['DetailType'] === UserRetrieved::class
                         && $arg['Entries'][0]['EventBusName'] === 'users'
@@ -52,19 +39,15 @@ class EventBridgeTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_with_action()
     {
-        $jane = $this->createJane();
-
-        $janeRetrieved = new UserRetrievedWithCustomName($jane);
+        $janeRetrieved = new UserRetrievedWithCustomName($this->createJane());
 
         $this->mockEventBridge(function (MockInterface $eventBridge) use ($janeRetrieved) {
             $eventBridge
                 ->shouldReceive('putEvents')
                 ->once()
-                ->with(Mockery::on(function ($arg) use ($janeRetrieved) {
+                ->with(m::on(function ($arg) use ($janeRetrieved) {
                     return $arg['Entries'][0]['Detail'] === json_encode($janeRetrieved)
-                        && $arg['Entries'][0]['DetailType'] === 'user.retrieved'
-                        && $arg['Entries'][0]['EventBusName'] === 'users'
-                        && $arg['Entries'][0]['Source'] === 'my-app';
+                        && $arg['Entries'][0]['DetailType'] === 'user.retrieved';
                 }));
         });
 
@@ -74,21 +57,18 @@ class EventBridgeTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_with_action_and_custom_payload()
     {
-        $jane = $this->createJane();
-
-        $janeRetrieved = new UserRetrievedWithCustomPayload($jane);
+        $janeRetrieved = new UserRetrievedWithCustomPayload($this->createJane());
 
         $this->mockEventBridge(function (MockInterface $eventBridge) use ($janeRetrieved) {
             $eventBridge
                 ->shouldReceive('putEvents')
                 ->once()
-                ->with(Mockery::on(function ($arg) use ($janeRetrieved) {
+                ->with(m::on(function ($arg) use ($janeRetrieved) {
                     $customPayload = array_merge($janeRetrieved->broadcastWith(), ['socket' => null]);
 
                     return $arg['Entries'][0]['Detail'] === json_encode($customPayload)
                         && $arg['Entries'][0]['DetailType'] === UserRetrievedWithCustomPayload::class
-                        && $arg['Entries'][0]['EventBusName'] === 'users'
-                        && $arg['Entries'][0]['Source'] === 'my-app';
+                        && $arg['Entries'][0]['EventBusName'] === 'users';
                 }));
         });
 
@@ -98,37 +78,55 @@ class EventBridgeTest extends TestCase
     /** @test */
     public function it_broadcasts_basic_event_to_multiple_channels_as_buses()
     {
-        $jane = $this->createJane();
-
-        $janeRetrieved = new UserRetrievedWithMultipleChannels($jane);
+        $janeRetrieved = new UserRetrievedWithMultipleChannels($this->createJane());
 
         $this->mockEventBridge(function (MockInterface $eventBridge) use ($janeRetrieved) {
             $eventBridge
                 ->shouldReceive('putEvents')
                 ->once()
-                ->with(Mockery::on(function ($arg) use ($janeRetrieved) {
+                ->with(m::on(function ($arg) use ($janeRetrieved) {
                     return collect($janeRetrieved->broadcastOn())
                         ->map(function ($channel, $key) use ($arg, $janeRetrieved) {
                             return $arg['Entries'][$key]['Detail'] === json_encode($janeRetrieved)
                                 && $arg['Entries'][$key]['DetailType'] === UserRetrievedWithMultipleChannels::class
-                                && $arg['Entries'][$key]['EventBusName'] === $channel
-                                && $arg['Entries'][$key]['Source'] === 'my-app';
+                                && $arg['Entries'][$key]['EventBusName'] === $channel;
                         })
                         ->filter()
-                        ->count() > 0;
+                        ->count() === 2;
                 }));
         });
 
         event($janeRetrieved);
     }
 
-    /**
-     * @return User
-     */
-    protected function createJane()
+    /** @test */
+    public function it_can_use_a_source()
+    {
+        config(['broadcasting.connections.eventbridge.source' => 'some-other-source']);
+
+        $janeRetrieved = new UserRetrievedWithMultipleChannels($this->createJane());
+
+        $this->mockEventBridge(function (MockInterface $eventBridge) use ($janeRetrieved) {
+            $eventBridge
+                ->shouldReceive('putEvents')
+                ->once()
+                ->with(m::on(function ($arg) use ($janeRetrieved) {
+                    return collect($janeRetrieved->broadcastOn())
+                            ->map(function ($channel, $key) use ($arg) {
+                                return $arg['Entries'][$key]['Source'] === 'some-other-source';
+                            })
+                            ->filter()
+                            ->count() > 0;
+                }));
+        });
+
+        event($janeRetrieved);
+    }
+
+    protected function createJane(): User
     {
         return User::create([
-            'name' => 'Jane',
+            'name' => 'Jane Doe',
             'email' => 'jane@doe.com',
             'password' => 'shh',
         ])->fresh();

--- a/tests/Pub/Broadcasting/Broadcasters/EventBridgeBroadcasterTest.php
+++ b/tests/Pub/Broadcasting/Broadcasters/EventBridgeBroadcasterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests\Pub\Broadcasting\Broadcasters;
+
+use PodPoint\AwsPubSub\EventServiceProvider;
+use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\EventBridgeBroadcaster;
+use PodPoint\AwsPubSub\Tests\TestCase;
+
+class EventBridgeBroadcasterTest extends TestCase
+{
+    /** @test */
+    public function it_can_instantiate_the_broadcaster()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createEventBridgeDriver([
+            'driver' => 'eventbridge',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'region' => 'eu-west-1',
+            'event_bus' => 'default',
+            'source' => 'my-app',
+        ]);
+
+        $this->assertInstanceOf(EventBridgeBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_optional_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createEventBridgeDriver([
+            'driver' => 'eventbridge',
+            'region' => 'eu-west-1',
+            'event_bus' => 'default',
+            'source' => 'my-app',
+        ]);
+
+        $this->assertInstanceOf(EventBridgeBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_null_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createEventBridgeDriver([
+            'driver' => 'eventbridge',
+            'key' => null,
+            'secret' => null,
+            'region' => 'eu-west-1',
+            'event_bus' => 'default',
+            'source' => 'my-app',
+        ]);
+
+        $this->assertInstanceOf(EventBridgeBroadcaster::class, $broadcaster);
+    }
+}

--- a/tests/Pub/Broadcasting/Broadcasters/SnsBroadcasterTest.php
+++ b/tests/Pub/Broadcasting/Broadcasters/SnsBroadcasterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests\Pub\Broadcasting\Broadcasters;
+
+use Mockery as m;
+use Mockery\MockInterface;
+use PodPoint\AwsPubSub\EventServiceProvider;
+use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\SnsBroadcaster;
+use PodPoint\AwsPubSub\Tests\Pub\Concerns\InteractsWithSns;
+use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Events\UserRetrieved;
+use PodPoint\AwsPubSub\Tests\Pub\TestClasses\Models\User;
+use PodPoint\AwsPubSub\Tests\TestCase;
+
+class SnsBroadcasterTest extends TestCase
+{
+    use InteractsWithSns;
+
+    /** @test */
+    public function it_can_instantiate_the_broadcaster()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createSnsDriver([
+            'driver' => 'sns',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertInstanceOf(SnsBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_optional_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createSnsDriver([
+            'driver' => 'sns',
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertInstanceOf(SnsBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_null_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createSnsDriver([
+            'driver' => 'sns',
+            'key' => null,
+            'secret' => null,
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertInstanceOf(SnsBroadcaster::class, $broadcaster);
+    }
+}

--- a/tests/Pub/Concerns/InteractsWithSns.php
+++ b/tests/Pub/Concerns/InteractsWithSns.php
@@ -5,11 +5,27 @@ namespace PodPoint\AwsPubSub\Tests\Pub\Concerns;
 use Aws\Sns\SnsClient;
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
+use Illuminate\Foundation\Application;
 use Mockery as m;
 use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\SnsBroadcaster;
 
 trait InteractsWithSns
 {
+    /**
+     * @param  Application  $app
+     */
+    public function getEnvironmentSetUp($app)
+    {
+        $app->config->set('broadcasting.default', 'sns');
+        $app->config->set('broadcasting.connections.sns', [
+            'driver' => 'sns',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+    }
+
     /**
      * Mocks the SnsClient through the SnsBroadcaster and the BroadcastManager.
      *
@@ -20,7 +36,12 @@ trait InteractsWithSns
     {
         $sns = m::mock(SnsClient::class, $mock);
 
-        $broadcaster = m::mock(SnsBroadcaster::class, [$sns])->makePartial();
+        $connection = config('broadcasting.default');
+        $broadcaster = m::mock(SnsBroadcaster::class, [
+            $sns,
+            config("broadcasting.connections.{$connection}.arn-prefix", ''),
+            config("broadcasting.connections.{$connection}.arn-suffix", ''),
+        ])->makePartial();
 
         $this->swap(BroadcasterContract::class, $broadcaster);
 

--- a/tests/Sub/Queue/Connectors/SqsSnsConnectorTest.php
+++ b/tests/Sub/Queue/Connectors/SqsSnsConnectorTest.php
@@ -11,7 +11,14 @@ class SqsSnsConnectorTest extends TestCase
     /** @test */
     public function it_can_instantiate_the_connector_and_connect_to_the_queue()
     {
-        $queue = (new SqsSnsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = (new SqsSnsConnector)->connect([
+            'driver' => 'sqs-sns',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',
+            'queue' => 'default',
+            'region' => 'eu-west-1',
+        ]);
 
         $this->assertInstanceOf(SqsSnsQueue::class, $queue);
     }
@@ -19,7 +26,14 @@ class SqsSnsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_prefix()
     {
-        $queue = (new SqsSnsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = (new SqsSnsConnector)->connect([
+            'driver' => 'sqs-sns',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',
+            'queue' => 'default',
+            'region' => 'eu-west-1',
+        ]);
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
     }
@@ -27,10 +41,44 @@ class SqsSnsConnectorTest extends TestCase
     /** @test */
     public function it_can_use_a_queue_suffix()
     {
-        config(['queue.connections.pub-sub.suffix' => '-testing']);
-
-        $queue = (new SqsSnsConnector)->connect(config('queue.connections.pub-sub'));
+        $queue = (new SqsSnsConnector)->connect([
+            'driver' => 'sqs-sns',
+            'key' => null,
+            'secret' => null,
+            'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',
+            'queue' => 'default',
+            'suffix' => '-testing',
+            'region' => 'eu-west-1',
+        ]);
 
         $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default-testing', $queue->getQueue(null));
+    }
+
+    /** @test */
+    public function it_supports_optional_aws_credentials()
+    {
+        $queue = (new SqsSnsConnector)->connect([
+            'driver' => 'sqs-sns',
+            'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',
+            'queue' => 'default',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
+    }
+
+    /** @test */
+    public function it_supports_null_aws_credentials()
+    {
+        $queue = (new SqsSnsConnector)->connect([
+            'driver' => 'sqs-sns',
+            'key' => null,
+            'secret' => null,
+            'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',
+            'queue' => 'default',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertEquals('https://sqs.eu-west-1.amazonaws.com/13245/default', $queue->getQueue(null));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends Orchestra
      * @param  \Illuminate\Foundation\Application  $app
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             AwsPubSubServiceProvider::class,
@@ -28,33 +28,14 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    protected function setTestDatabase($app)
-    {
-        /** DATABASE */
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver'   => 'sqlite',
-            'database' => ':memory:',
-            'prefix'   => '',
-        ]);
-    }
-
-    /**
      * Define environment setup.
      *
      * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app)
     {
-        $this->setSnsBroadcaster($app);
-
-        $this->setSubQueue($app);
-
-        $this->setTestDatabase($app);
+        $this->configureTestDatabase($app);
     }
 
     /**
@@ -69,52 +50,15 @@ abstract class TestCase extends Orchestra
 
     /**
      * @param  \Illuminate\Foundation\Application  $app
+     * @return void
      */
-    protected function setSnsBroadcaster($app): void
+    protected function configureTestDatabase($app)
     {
-        /** PUB */
-        $app['config']->set('broadcasting.default', 'sns');
-        $app['config']->set('broadcasting.connections.sns', [
-            'driver' => 'sns',
-            'key' => 'dummy-key',
-            'secret' => 'dummy-secret',
-            'arn-prefix' => 'aws:arn:12345:',
-            'arn-suffix' => '',
-            'region' => 'eu-west-1',
-        ]);
-    }
-
-    /**
-     * @param  \Illuminate\Foundation\Application  $app
-     */
-    protected function setEventBridgeBroadcaster($app)
-    {
-        /** PUB */
-        $app['config']->set('broadcasting.default', 'eventbridge');
-        $app['config']->set('broadcasting.connections.eventbridge', [
-            'driver' => 'eventbridge',
-            'key' => 'dummy-key',
-            'secret' => 'dummy-secret',
-            'region' => 'eu-west-1',
-            'event_bus' => 'default',
-            'source' => 'my-app',
-        ]);
-    }
-
-    /**
-     * @param  \Illuminate\Foundation\Application  $app
-     */
-    protected function setSubQueue($app): void
-    {
-        /** SUB */
-        $app['config']->set('queue.connections.pub-sub', [
-            'driver' => 'sqs-sns',
-            'key' => 'dummy-key',
-            'secret' => 'dummy-secret',
-            'prefix' => 'https://sqs.eu-west-1.amazonaws.com/13245',
-            'queue' => 'default',
-            'suffix' => '',
-            'region' => 'eu-west-1',
+        $app->config->set('database.default', 'testbench');
+        $app->config->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
         ]);
     }
 }


### PR DESCRIPTION
When environment variables are not set for example:
```php
'sns' => [
    'key' => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
],
```
which gives
```php
'sns' => [
    'key' => null,
    'secret' => null,
    'region' => 'us-east-1',
],
```
we **should not** try to pass an array of empty credentials to the AWS Client like
```php
'credentials' => [
    'key' => null,
    'secret' => null,
],
'region' => 'eu-west-1',
```
but instead should completely omit the `credentials` like so
```php
'region' => 'eu-west-1',
```

This is so we can leverage EC2 Assumed IAM Roles to automatically authenticate with IAM Roles if needed.