### PR TITLE
[SWP-5969] - Allow missing credentials to make use of injected IAM role credentials

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,7 +60,7 @@ jobs:
           run: |
             composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
             composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-            composer update --prefer-dist --no-interaction --no-progress
+            composer update --prefer-dist --no-interaction --no-progress --no-plugins
 
       -   name: Execute tests
           run: vendor/bin/phpunit

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -120,7 +120,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Make sure some AWS credentials were provided to the configuration array.
      *
-     * @param array $config
+     * @param  array  $config
      * @return bool
      */
     private static function configHasCredentials(array $config): bool

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -120,6 +120,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Make sure some AWS credentials were provided to the configuration array.
      *
+     * @param array $config
      * @return bool
      */
     private static function configHasCredentials(array $config): bool

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -47,7 +47,7 @@ class EventServiceProvider extends ServiceProvider
      * @param  array  $config
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      */
-    protected function createSnsDriver(array $config): \Illuminate\Contracts\Broadcasting\Broadcaster
+    public function createSnsDriver(array $config): \Illuminate\Contracts\Broadcasting\Broadcaster
     {
         $config = self::prepareConfigurationCredentials($config);
 
@@ -81,9 +81,7 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->app->resolving(BroadcastManager::class, function (BroadcastManager $manager) {
             $manager->extend('eventbridge', function (Container $app, array $config) {
-                return $this->createEventBridgeDriver(array_merge($config, [
-                    'version' => '2015-10-07',
-                ]));
+                return $this->createEventBridgeDriver($config);
             });
         });
     }
@@ -94,12 +92,12 @@ class EventServiceProvider extends ServiceProvider
      * @param  array  $config
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      */
-    protected function createEventBridgeDriver(array $config): \Illuminate\Contracts\Broadcasting\Broadcaster
+    public function createEventBridgeDriver(array $config): \Illuminate\Contracts\Broadcasting\Broadcaster
     {
         $config = self::prepareConfigurationCredentials($config);
 
         return new EventBridgeBroadcaster(
-            new EventBridgeClient($config),
+            new EventBridgeClient(array_merge($config, ['version' => '2015-10-07'])),
             $config['source'] ?? ''
         );
     }
@@ -112,10 +110,22 @@ class EventServiceProvider extends ServiceProvider
      */
     public static function prepareConfigurationCredentials(array $config): array
     {
-        if (Arr::has($config, ['key', 'secret'])) {
+        if (static::configHasCredentials($config)) {
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
         return $config;
+    }
+
+    /**
+     * Make sure some AWS credentials were provided to the configuration array.
+     *
+     * @return bool
+     */
+    private static function configHasCredentials(array $config): bool
+    {
+        return Arr::has($config, ['key', 'secret'])
+            && is_string(Arr::get($config, 'key'))
+            && is_string(Arr::get($config, 'secret'));
     }
 }

--- a/tests/Pub/Broadcasting/Broadcasters/EventBridgeBroadcasterTest.php
+++ b/tests/Pub/Broadcasting/Broadcasters/EventBridgeBroadcasterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests\Pub\Broadcasting\Broadcasters;
+
+use PodPoint\AwsPubSub\EventServiceProvider;
+use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\EventBridgeBroadcaster;
+use PodPoint\AwsPubSub\Tests\TestCase;
+
+class EventBridgeBroadcasterTest extends TestCase
+{
+    /** @test */
+    public function it_can_instantiate_the_broadcaster()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createEventBridgeDriver([
+            'driver' => 'eventbridge',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'region' => 'eu-west-1',
+            'event_bus' => 'default',
+            'source' => 'my-app',
+        ]);
+
+        $this->assertInstanceOf(EventBridgeBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_optional_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createEventBridgeDriver([
+            'driver' => 'eventbridge',
+            'region' => 'eu-west-1',
+            'event_bus' => 'default',
+            'source' => 'my-app',
+        ]);
+
+        $this->assertInstanceOf(EventBridgeBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_null_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createEventBridgeDriver([
+            'driver' => 'eventbridge',
+            'key' => null,
+            'secret' => null,
+            'region' => 'eu-west-1',
+            'event_bus' => 'default',
+            'source' => 'my-app',
+        ]);
+
+        $this->assertInstanceOf(EventBridgeBroadcaster::class, $broadcaster);
+    }
+}

--- a/tests/Pub/Broadcasting/Broadcasters/SnsBroadcasterTest.php
+++ b/tests/Pub/Broadcasting/Broadcasters/SnsBroadcasterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PodPoint\AwsPubSub\Tests\Pub\Broadcasting\Broadcasters;
+
+use PodPoint\AwsPubSub\EventServiceProvider;
+use PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters\SnsBroadcaster;
+use PodPoint\AwsPubSub\Tests\Pub\Concerns\InteractsWithSns;
+use PodPoint\AwsPubSub\Tests\TestCase;
+
+class SnsBroadcasterTest extends TestCase
+{
+    use InteractsWithSns;
+
+    /** @test */
+    public function it_can_instantiate_the_broadcaster()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createSnsDriver([
+            'driver' => 'sns',
+            'key' => 'dummy-key',
+            'secret' => 'dummy-secret',
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertInstanceOf(SnsBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_optional_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createSnsDriver([
+            'driver' => 'sns',
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertInstanceOf(SnsBroadcaster::class, $broadcaster);
+    }
+
+    /** @test */
+    public function it_supports_null_aws_credentials()
+    {
+        $broadcaster = (new EventServiceProvider($this->app))->createSnsDriver([
+            'driver' => 'sns',
+            'key' => null,
+            'secret' => null,
+            'arn-prefix' => 'aws:arn:12345:',
+            'region' => 'eu-west-1',
+        ]);
+
+        $this->assertInstanceOf(SnsBroadcaster::class, $broadcaster);
+    }
+}


### PR DESCRIPTION
This is to support the migration from IAM users to IAM roles for applications running earlier versions of Laravel (< 8). 