### PR TITLE
fix: check if aws key and secret are not empty

### DIFF
--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -124,8 +124,6 @@ class EventServiceProvider extends ServiceProvider
      */
     private static function configHasCredentials(array $config): bool
     {
-        return Arr::has($config, ['key', 'secret'])
-            && is_string(Arr::get($config, 'key'))
-            && is_string(Arr::get($config, 'secret'));
+        return ! empty($config['key']) && ! empty($config['secret']);
     }
 }


### PR DESCRIPTION
if using `AWS_ACCESS_KEY_ID=''` or `AWS_SECRET_ACCESS_KEY=''` an exception will be thrown

```
Error executing "PutEvents" on "https://events.us-east-1.amazonaws.com"; AWS HTTP error: Client error: `POST https://events.us-east-1.amazonaws.com` resulted in a `400 Bad Request` response:
{"__type":"UnrecognizedClientException","message":"The security token included in the request is invalid."}
```