### PR TITLE
Added support for illuminate/support 10.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.155",
-        "illuminate/support": "^8.52 || ^9.0"
+        "illuminate/support": "^8.52|^9.0|^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0 || ^7.0"
+        "orchestra/testbench": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In order to be able to use package with laravel 10 it should be possible to install illuminate/support versions 10.*