### PR TITLE
Add error handling for eventbridge put events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.155",
-        "illuminate/support": "^8.52 || ^9.0"
+        "illuminate/support": "^8.52 || ^9.0 || ^10.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.155",
-        "illuminate/support": "^8.52 || ^9.0 || ^10.0"
+        "illuminate/support": "^8.52 || ^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0 || ^7.0"

--- a/src/Pub/Broadcasting/Broadcasters/EventBridgeBroadcaster.php
+++ b/src/Pub/Broadcasting/Broadcasters/EventBridgeBroadcaster.php
@@ -4,6 +4,7 @@ namespace PodPoint\AwsPubSub\Pub\Broadcasting\Broadcasters;
 
 use Aws\EventBridge\EventBridgeClient;
 use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Support\Facades\Log;
 
 class EventBridgeBroadcaster extends Broadcaster
 {
@@ -52,9 +53,19 @@ class EventBridgeBroadcaster extends Broadcaster
     {
         $events = $this->mapToEventBridgeEntries($channels, $event, $payload);
 
-        $this->eventBridgeClient->putEvents([
+        $eventBridgeResult = $this->eventBridgeClient->putEvents([
             'Entries' => $events,
         ]);
+
+        if ($eventBridgeResult->get('FailedEntryCount') > 0) {
+            $errors = collect();
+            foreach ($eventBridgeResult->get('Entries') as $entry) {
+                if (isset($entry['ErrorMessage'])) {
+                    $errors->push([$entry['ErrorMessage'], $entry['ErrorCode']]);
+                }
+            }
+            Log::error('Failed to send event to EventBridge', ['errors' => $errors->all()]);
+        }
     }
 
     /**

--- a/src/Pub/Broadcasting/Broadcasters/EventBridgeBroadcaster.php
+++ b/src/Pub/Broadcasting/Broadcasters/EventBridgeBroadcaster.php
@@ -64,7 +64,7 @@ class EventBridgeBroadcaster extends Broadcaster
                     $errors->push([$entry['ErrorMessage'], $entry['ErrorCode']]);
                 }
             }
-            Log::error('Failed to send event to EventBridge', ['errors' => $errors->all()]);
+            Log::error('Failed to send events to EventBridge', ['errors' => $errors->all()]);
         }
     }
 


### PR DESCRIPTION
During debugging I notice that this library fails silently on eventbridge `putEvents`, by not evaluating the `Aws\Result` class that is returned from the `putEvents` method.

For our case it was enough to just log the error to be able to troubleshoot it, but mit might be worth to throw an exception when this occurs. But to not break existing flows, I leave it to the maintainers to decide.