### PR TITLE
fix: undeleted messages

### DIFF
--- a/src/Sub/Queue/Jobs/SnsEventDispatcherJob.php
+++ b/src/Sub/Queue/Jobs/SnsEventDispatcherJob.php
@@ -31,13 +31,9 @@ class SnsEventDispatcherJob extends SqsJob implements JobContract
                 'payload' => json_decode($this->snsMessage(), true),
                 'subject' => $this->snsSubject(),
             ]);
-
-            $this->delete();
-
-            return;
         }
 
-        $this->release();
+        $this->delete();
     }
 
     /**

--- a/tests/Sub/Queue/Jobs/SnsEventDispatcherJobTest.php
+++ b/tests/Sub/Queue/Jobs/SnsEventDispatcherJobTest.php
@@ -132,7 +132,7 @@ class SnsEventDispatcherJobTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_handle_messages_where_the_event_name_to_trigger_cannot_be_resolved_and_release_the_message_onto_the_queue()
+    public function it_will_not_handle_messages_where_the_event_name_to_trigger_cannot_be_resolved_and_delete_the_message_from_the_queue()
     {
         $this->mockedJobData = $this->mockedRichNotificationMessage([
             'TopicArn' => '',
@@ -140,8 +140,8 @@ class SnsEventDispatcherJobTest extends TestCase
         ])['Messages'][0];
 
         $job = $this->getJob();
-        $job->shouldNotReceive('delete');
-        $job->shouldReceive('release')->once();
+        $job->shouldReceive('delete')->once();
+        $job->shouldNotReceive('release');
 
         $job->fire();
 


### PR DESCRIPTION
Because we never explicitly tell the queue / Laravel that we're done (or not) processing the initial message from the pubsub queue, they never get deleted and keep being retried 3 times before bloating the DLQ table `failed_jobs`.