### PR TITLE
feat: Add `Laravel 12` support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1, 8.2, 8.3, 8.4]
-        laravel: [8.*, 9.*, 10.*, 11.*]
+        laravel: [8.*, 9.*, 10.*, 11.*, 12.*]
         exclude:
           - php: 8.0
             laravel: 10.*

--- a/composer.json
+++ b/composer.json
@@ -1,56 +1,56 @@
 {
-  "name": "pod-point/laravel-aws-pubsub",
-  "description": "A Laravel broadcasting driver and queue driver that broadcasts and listens to published events utilising AWS SNS, EventBridge and SQS.",
-  "keywords": [
-    "laravel",
-    "broadcasting",
-    "broadcast",
-    "queue",
-    "listeners",
-    "pubsub",
-    "aws",
-    "sns",
-    "sqs"
-  ],
-  "homepage": "https://github.com/pod-point/laravel-aws-pubsub",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Pod Point Software Team",
-      "email": "software@pod-point.com"
+    "name": "pod-point/laravel-aws-pubsub",
+    "description": "A Laravel broadcasting driver and queue driver that broadcasts and listens to published events utilising AWS SNS, EventBridge and SQS.",
+    "keywords": [
+        "laravel",
+        "broadcasting",
+        "broadcast",
+        "queue",
+        "listeners",
+        "pubsub",
+        "aws",
+        "sns",
+        "sqs"
+    ],
+    "homepage": "https://github.com/pod-point/laravel-aws-pubsub",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Pod Point Software Team",
+            "email": "software@pod-point.com"
+        }
+    ],
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "aws/aws-sdk-php": "^3.155",
+        "illuminate/support": "^8.52|^9.0|^10.0|^11.0|^12.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "PodPoint\\AwsPubSub\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PodPoint\\AwsPubSub\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": ["PodPoint\\AwsPubSub\\AwsPubSubServiceProvider"]
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit --colors=always",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true
     }
-  ],
-  "require": {
-    "php": "^8.0",
-    "ext-json": "*",
-    "aws/aws-sdk-php": "^3.155",
-    "illuminate/support": "^8.52|^9.0|^10.0|^11.0|^12.0"
-  },
-  "require-dev": {
-    "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "PodPoint\\AwsPubSub\\": "src"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "PodPoint\\AwsPubSub\\Tests\\": "tests"
-    }
-  },
-  "extra": {
-    "laravel": {
-      "providers": ["PodPoint\\AwsPubSub\\AwsPubSubServiceProvider"]
-    }
-  },
-  "scripts": {
-    "test": "vendor/bin/phpunit --colors=always",
-    "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "config": {
-    "sort-packages": true
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,58 +1,56 @@
 {
-    "name": "pod-point/laravel-aws-pubsub",
-    "description": "A Laravel broadcasting driver and queue driver that broadcasts and listens to published events utilising AWS SNS, EventBridge and SQS.",
-    "keywords": [
-        "laravel",
-        "broadcasting",
-        "broadcast",
-        "queue",
-        "listeners",
-        "pubsub",
-        "aws",
-        "sns",
-        "sqs"
-    ],
-    "homepage": "https://github.com/pod-point/laravel-aws-pubsub",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Pod Point Software Team",
-            "email": "software@pod-point.com"
-        }
-    ],
-    "require": {
-        "php": "^8.0",
-        "ext-json": "*",
-        "aws/aws-sdk-php": "^3.155",
-        "illuminate/support": "^8.52|^9.0|^10.0|^11.0"
-    },
-    "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "PodPoint\\AwsPubSub\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "PodPoint\\AwsPubSub\\Tests\\": "tests"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "PodPoint\\AwsPubSub\\AwsPubSubServiceProvider"
-            ]
-        }
-    },
-    "scripts": {
-        "test": "vendor/bin/phpunit --colors=always",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "config": {
-        "sort-packages": true
+  "name": "pod-point/laravel-aws-pubsub",
+  "description": "A Laravel broadcasting driver and queue driver that broadcasts and listens to published events utilising AWS SNS, EventBridge and SQS.",
+  "keywords": [
+    "laravel",
+    "broadcasting",
+    "broadcast",
+    "queue",
+    "listeners",
+    "pubsub",
+    "aws",
+    "sns",
+    "sqs"
+  ],
+  "homepage": "https://github.com/pod-point/laravel-aws-pubsub",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Pod Point Software Team",
+      "email": "software@pod-point.com"
     }
+  ],
+  "require": {
+    "php": "^8.0",
+    "ext-json": "*",
+    "aws/aws-sdk-php": "^3.155",
+    "illuminate/support": "^8.52|^9.0|^10.0|^11.0|^12.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "PodPoint\\AwsPubSub\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "PodPoint\\AwsPubSub\\Tests\\": "tests"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": ["PodPoint\\AwsPubSub\\AwsPubSubServiceProvider"]
+    }
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit --colors=always",
+    "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "config": {
+    "sort-packages": true
+  }
 }


### PR DESCRIPTION
### My Fork with Updates
- https://github.com/cleanscript/laravel-aws-pubsub
- Resolving the `illuminate` dependency allows upgrading to L12 - https://github.com/cleanscript/laravel-aws-pubsub/commit/7a2b07bc1d8aa3f30ccbd1ef9fcf83505ae6ce92